### PR TITLE
added maxlength to role string in schema

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -12,7 +12,7 @@ var userSchema = new mongoose.Schema({
 	passwordResetExpires: Date,
 	loginAttempts: { type: Number, required: true, default: 0 },
 	lockUntil: Date,
-	role: String
+	role: { type: String, maxlength: 16 }
 });
 
 userSchema.virtual('isLocked').get(function() {


### PR DESCRIPTION
Hey Alex,

Here's a very lazy pull request. I have not tested the change I made and it's possible it might break the application or result in unexpected behavior.

The intention is to set a `maxlength` value for the role string in your user schema. It may be better to close this PR and focus on validating that the role provided on user creation matches one of the expected roles like "user", "admin", etc.
